### PR TITLE
Add a time estimate flag to the CLI options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Do you have way too many things to do and don't know where to start? Use this sc
 
 ## Prerequisites
 
-* Python 2.7.x - primarily due to the RtmAPI module being built with this version.
-* Python modules (`pip install` these):
-	* rtmapi
-	* httplib2
-	* colorama
-	* progress
+- Python 2.7.x - primarily due to the RtmAPI module being built with this version.
+- Python modules (`pip install` these):
+  - rtmapi
+  - httplib2
+  - colorama
+  - progress
 
 ## Installing
 
@@ -19,17 +19,18 @@ Clone this repo to your local computer.
 
 Run `rtmr.py`. e.g.:
 
-```./rtmr.py```
+`./rtmr.py`
 
 or perhaps:
 
-```python2.7 rtmr.py```
+`python2.7 rtmr.py`
 
 ### Options
 
-* `-l` / `--list` - specify an RTM list to search within. Note that if your list has spaces in it, you must quote it. i.e. "Home Tasks" or 'Grocery List'
-* `-t` / `--tag` - specify an RTM tag to search within or add to your search filter. 
-* `-p` / `--priority` - specify an RTM priority to search within or add to your search filter. 
+- `-l` / `--list` - specify an RTM list to search within. Note that if your list has spaces in it, you must quote it. i.e. "Home Tasks" or 'Grocery List'
+- `-t` / `--tag` - specify an RTM tag to search within or add to your search filter.
+- `-p` / `--priority` - specify an RTM priority to search within or add to your search filter.
+- `-e` / `--estimate` - specify the upper limit of the time estimate of the task (in hours or minutes).
 
 ### Examples
 
@@ -49,15 +50,27 @@ Find a random task in your _Home Stuff_ list that is also tagged with the _finan
 
 `./rtmr.py -l 'House Stuff' -t financial`
 
-Find all priority 1 tasks that are tagged as _financial_:
+Find a random priority 1 task that is tagged as _financial_:
 
 `./rtmr.py -p 1 -t financial`
 
-*Note* that specifying multiple search filter flags `AND`s them together (not `OR`).
+Find a random task in your _Current_ list with a maximum time estimate of 2.5 hours:
+
+`./rtmr.py -l current -e 2.5`
+
+`./rtmr.py -l current -e 2.5h`
+
+Find a random priority 1 task with a maximum time estimate of 10 minutes (for the `-e` flag, use any word after the # starting with 'm'):
+
+`./rtmr.py -p 1 -e 10m`
+
+`./rtmr.py -p 1 -e 10mins`
+
+_Note_ that specifying multiple search filter flags `AND`s them together (not `OR`).
 
 ## Bonus Script - Randomize a List of Ordered Numbers, 1 to N.
 
-Many days, I have To Dos that crop up outside of what's in RTM. I tend to write these down. To fight the overwhelm, I number the items, then randomize the list using the `shuffle.py` script. 
+Many days, I have To Dos that crop up outside of what's in RTM. I tend to write these down. To fight the overwhelm, I number the items, then randomize the list using the `shuffle.py` script.
 
 For example, if I have 4 items (1, 2, 3, 4 ), after shuffling the list, it may become [3, 1, 4, 2].
 
@@ -65,15 +78,15 @@ For example, if I have 4 items (1, 2, 3, 4 ), after shuffling the list, it may b
 
 Please add your suggestions, bugs you've found or send us pull requests via this GitHub repo!
 
-The point of this tool is to make your life a little bit more manageable by removing one more decision - what to do/where to start? So that means it should *not* make it more complicated by having/adding so many features that you need to do/learn 1 more thing! As much as I like powerful software, I've fought the urge to add every single feature that has occurred to me. 
+The point of this tool is to make your life a little bit more manageable by removing one more decision - what to do/where to start? So that means it should _not_ make it more complicated by having/adding so many features that you need to do/learn 1 more thing! As much as I like powerful software, I've fought the urge to add every single feature that has occurred to me.
 
 ## Authors
 
-* **Khalid J Hosein**
+- **Khalid J Hosein**
 
 ## License
 
-This project is licensed under the Mozilla Public License 2.0 (MPL-2.0)  - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the Mozilla Public License 2.0 (MPL-2.0) - see the [LICENSE](LICENSE) file for details.
 
 ## Disclaimer
 


### PR DESCRIPTION
`-e` or `--estimate`

can specify the time in either minutes or hours (hours is default if only a number is provided).